### PR TITLE
Add github workflow to publish package when new tag version created

### DIFF
--- a/.github/workflows/pypi-deploy.yml
+++ b/.github/workflows/pypi-deploy.yml
@@ -1,0 +1,42 @@
+name: Publish to PyPI
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  pypi-publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/formal-sqlcommenter
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build a binary wheel and a source tarball
+        run: >-
+          python3 -m
+          build
+          --sdist
+          --wheel
+          --outdir ./dist
+      - name: Log package files
+        run: ls -l ./dist
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Changes
- Add GitHub workflow to automatically publish new package version

## How to use
- Create a new tag on GitHub with this format `v[0-9]+.[0-9]+.[0-9]+`
- Examples: 
  - v1.3.2
  - v11.13.20

## Post Merge Actions
- [x] Add `pypi` environment to the repository

## Context
- All steps have already been tested locally except "Publish package distributions to PyPI" This step will be tested when we want to publish a new version.